### PR TITLE
remove rules from job

### DIFF
--- a/templates/jobs/check_changelog.yml
+++ b/templates/jobs/check_changelog.yml
@@ -1,6 +1,4 @@
 .check-changelog:
-  rules:
-    - if: ($CI_PIPELINE_SOURCE == "merge_request_event") && ($CI_MERGE_REQUEST_TARGET_BRANCH_NAME == $CI_DEFAULT_BRANCH)
   script:
     - git --no-pager diff --name-only "$(git merge-base "$CI_COMMIT_SHA" "$CI_MERGE_REQUEST_DIFF_BASE_SHA")" "$CI_COMMIT_SHA" | grep CHANGELOG.md || exit_code=$?
     - |


### PR DESCRIPTION
removing rules since we want this job to be executed also for branches that are not the default branch, like `2.x` (job will follow top level workflow rules)
