### PR TITLE
add rules for e2e pkg tests

### DIFF
--- a/templates/jobs/pkgs/e2e_tests.yml
+++ b/templates/jobs/pkgs/e2e_tests.yml
@@ -45,3 +45,6 @@
       - newproject
     expire_in: 1 day
     when: always
+  rules:
+    - if: $CI_MERGE_REQUEST_IID
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH


### PR DESCRIPTION
Fixes `Could not find package xxxx/yyyy in a version matching dev-1.7.0#b5519344c26d5e5d23c4b3f1fb01575fa9e0f537 `
when tagging