### PR TITLE
refs #000: make sparkfabrik helm chart repo url configurable

### DIFF
--- a/scripts/helm3-init
+++ b/scripts/helm3-init
@@ -14,10 +14,10 @@ helm3-init() {
     echo "KUBE_NAMESPACE is missing."
     exit 1
   fi
-  echo "Current KUBE_NAMESPACE=${KUBE_NAMESPACE}\n"
-  kubectl create ns $KUBE_NAMESPACE || true
+  echo "Current KUBE_NAMESPACE=${KUBE_NAMESPACE}"
+  kubectl create ns "$KUBE_NAMESPACE" || true
   helm3 repo add "stable" "https://charts.helm.sh/stable"
-  helm3 repo add "sparkfabrik" "https://storage.googleapis.com/spark-helm-charts"
+  helm3 repo add "sparkfabrik" "${SPARKFABRIK_CHART_REPO_URL:-https://storage.googleapis.com/spark-helm-charts}"
   helm3 repo update
 }
 


### PR DESCRIPTION
useful for when the url is not the usual bucket 