### PR TITLE
refs platform/#2550: remove quotes in X-CDN-cache-status custom header

### DIFF
--- a/templates/jobs/gcloud-load-balancer-l7-cdn.yml
+++ b/templates/jobs/gcloud-load-balancer-l7-cdn.yml
@@ -170,7 +170,7 @@
       echo "Calculating the ENABLE_CACHE_STATUS_RESPONSE_HEADER_OPT ..."
       ENABLE_CACHE_STATUS_RESPONSE_HEADER_OPT=""
       if [ "${ENABLE_CACHE_STATUS_RESPONSE_HEADER}" = "true" ]; then
-        ENABLE_CACHE_STATUS_RESPONSE_HEADER_OPT="--custom-response-header \"X-CDN-cache-status:{cdn_cache_status}\""
+        ENABLE_CACHE_STATUS_RESPONSE_HEADER_OPT="--custom-response-header X-CDN-cache-status:{cdn_cache_status}"
       fi
     - !reference [.gcloud-load-balancer-l7-cdn-print-vars, script]
     - |


### PR DESCRIPTION
Using double quotas returned an error:

```
ERROR: (gcloud.compute.backend-services.update) Could not fetch resource:
155 - Invalid value for field 'resource.customResponseHeaders[0]': '"X-CDN-cache-status:{cdn_cache_status}"'. Must be a match of regex '[-!#$%&'*+.^_`|~0-9a-zA-Z]+:[	 -~]*'
```

We remove all quotas since the single quote is a permitted char as we can see in the error above.