### PR TITLE
refs #000: fix dind for containeros 105

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -8,6 +8,7 @@ services:
         "https://mirror.gcr.io",
         "--mtu=1300",
         "--network-control-plane-mtu=1300",
+        "--env DOCKER_IPTABLES_LEGACY=1"
       ]
 
 variables:


### PR DESCRIPTION
Add env variable for Docker Dind Service.
Github Issue related to DIND:
https://github.com/docker-library/docker/issues/463
https://github.com/docker-library/docker/pull/468#issuecomment-1878086606