### PR TITLE
feat: add a simple way to sleep jobs for debugging

### DIFF
--- a/scripts/src/functions.bash
+++ b/scripts/src/functions.bash
@@ -11,6 +11,29 @@ print-banner() {
   fi
 }
 
+print_job_info() {
+  print-banner "JOB INFO"
+
+  local PAD_LEN VAR_NAME
+  PAD_LEN=${PAD_LEN:-40}
+  printf "\e[1mCI Job informations:\e[0m\n"
+  for VAR_NAME in "HOSTNAME" "CI_JOB_NAME" "CI_JOB_NAME_SLUG" \
+    "CI_COMMIT_AUTHOR" "CI_RUNNER_EXECUTABLE_ARCH" \
+    "CI_RUNNER_DESCRIPTION"; do
+    printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "${VAR_NAME}:" "${!VAR_NAME}"
+  done
+
+  print-banner "END JOB INFO"
+}
+
+print_debug_sleep_help() {
+  print-banner "DEBUG SLEEP HELP"
+  echo "If DEBUG_JOB_SLEEP is 1 and CI_JOB_NAME_SLUG matches DEBUG_JOB_SLEEP_JOB_NAME, the job will sleep for the specified duration."
+  echo "You should set the variables like this: DEBUG_JOB_SLEEP=1 DEBUG_JOB_SLEEP_JOB_NAME=${CI_JOB_NAME_SLUG} DEBUG_JOB_SLEEP_DURATION=3600"
+  print-banner "END DEBUG SLEEP HELP"
+
+}
+
 create_kubeconfig() {
   print-banner "CREATING KUBECONFIG"
   KUBECONFIG="$(pwd)/kubeconfig"

--- a/scripts/src/functions.bash
+++ b/scripts/src/functions.bash
@@ -29,9 +29,9 @@ print_job_info() {
 print_debug_sleep_help() {
   print-banner "DEBUG SLEEP HELP"
   echo "If DEBUG_JOB_SLEEP is 1 and CI_JOB_NAME_SLUG matches DEBUG_JOB_SLEEP_JOB_NAME, the job will sleep for the specified duration."
-  echo "You should set the variables like this: DEBUG_JOB_SLEEP=1 DEBUG_JOB_SLEEP_JOB_NAME=${CI_JOB_NAME_SLUG} DEBUG_JOB_SLEEP_DURATION=3600"
+  echo "To activate it, you can set the variables as follows:"
+  echo "DEBUG_JOB_SLEEP=1 DEBUG_JOB_SLEEP_JOB_NAME=${CI_JOB_NAME_SLUG} DEBUG_JOB_SLEEP_DURATION=3600"
   print-banner "END DEBUG SLEEP HELP"
-
 }
 
 create_kubeconfig() {

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -100,9 +100,9 @@ variables:
       # Handle debug sleep.
       print_debug_sleep_help
       DEBUG_JOB_SLEEP_SECONDS=${DEBUG_JOB_SLEEP_SECONDS:-3600}  # Default to 1 hour if not set
-      if [ "$DEBUG_JOB_SLEEP" -eq 1 ] && [ "$CI_JOB_NAME_SLUG" == "$DEBUG_JOB_SLEEP_JOB_NAME" ]; then
-        echo "Sleeping for $DEBUG_JOB_SLEEP_SECONDS seconds..."
-        sleep $DEBUG_JOB_SLEEP_SECONDS
+      if [ "${DEBUG_JOB_SLEEP}" -eq 1 ] && [ "${CI_JOB_NAME_SLUG}" == "${DEBUG_JOB_SLEEP_JOB_NAME}" ]; then
+        echo "Sleeping for ${DEBUG_JOB_SLEEP_SECONDS} seconds..."
+        sleep "${DEBUG_JOB_SLEEP_SECONDS}"
       fi
 
 before_script:

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -9,7 +9,7 @@ services:
         "https://mirror.gcr.io",
         "--mtu=1460",
         "--network-control-plane-mtu=1460",
-        "--default-network-opt=bridge=com.docker.network.driver.mtu=1460"
+        "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
       ]
 variables:
   # When using dind service, we need to instruct docker to talk with
@@ -92,6 +92,16 @@ variables:
         source "/scripts/src/common.bash"
         source "/scripts/src/functions.bash"
         setup-gitlab-agent
+      fi
+
+      # Print some useful job info.
+      print_job_info
+
+      # Handle debug sleep.
+      print_debug_sleep_help
+      if [ "$DEBUG_JOB_SLEEP" -eq 1 ] && [ "$CI_JOB_NAME_SLUG" == "$DEBUG_JOB_SLEEP_JOB_NAME" ]; then
+        echo "Sleeping for $DEBUG_JOB_SLEEP_SECONDS seconds..."
+        sleep $DEBUG_JOB_SLEEP_SECONDS
       fi
 
 before_script:

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -99,6 +99,7 @@ variables:
 
       # Handle debug sleep.
       print_debug_sleep_help
+      DEBUG_JOB_SLEEP_SECONDS=${DEBUG_JOB_SLEEP_SECONDS:-3600}  # Default to 1 hour if not set
       if [ "$DEBUG_JOB_SLEEP" -eq 1 ] && [ "$CI_JOB_NAME_SLUG" == "$DEBUG_JOB_SLEEP_JOB_NAME" ]; then
         echo "Sleeping for $DEBUG_JOB_SLEEP_SECONDS seconds..."
         sleep $DEBUG_JOB_SLEEP_SECONDS


### PR DESCRIPTION
This is a way to sleep pipeline jobs before running for debugging purposes.

It works by setting the following variables:

1. `DEBUG_JOB_SLEEP`: boolean
2. `DEBUG_JOB_SLEEP_JOB_NAME`: $CI_JOB_NAME_SLUG
3. `DEBUG_JOB_SLEEP_SECONDS`: seconds (optional)