### PR TITLE
feat: add kube-linter binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 # Define the google cloud sdk image tag to use.
 ARG GOOGLE_CLOUD_CLI_IMAGE_TAG=489.0.0-alpine
 
+# Build go binaries
+FROM golang:1.23.0-alpine3.20 AS gobinaries
+
+# https://github.com/stackrox/kube-linter
+ENV KUBELINTER_VERSION=0.6.8
+RUN apk --no-cache add git \
+    && go install golang.stackrox.io/kube-linter/cmd/kube-linter@v${KUBELINTER_VERSION}
+
 FROM eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:${GOOGLE_CLOUD_CLI_IMAGE_TAG}
 
 # https://github.com/docker/compose/releases
@@ -63,6 +71,10 @@ RUN apk add --no-cache py-pip python3-dev curl make gettext bash openssl libffi-
 RUN pip install --no-cache-dir awscli==${AWS_CLI_VERSION} --break-system-packages
 
 RUN echo "source /google-cloud-sdk/path.bash.inc" >> /etc/profile
+
+# Install kube-linter copying the binary from the gobinaries stage
+COPY --from=gobinaries /go/bin/kube-linter /usr/local/bin/kube-linter
+RUN chmod +x /usr/local/bin/kube-linter
 
 COPY configs /configs
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added kube-linter (version 0.6.8) to the Docker image for Kubernetes manifest linting
- Introduced a multi-stage build to compile kube-linter from source
- Copied the kube-linter binary from the build stage to the final image
- Set proper permissions for the kube-linter binary
- Maintained existing functionality and versions of other tools in the image


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add kube-linter to the Docker image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Added a new build stage using golang:1.23.0-alpine3.20 to install <br>kube-linter<br> <li> Set KUBELINTER_VERSION environment variable to 0.6.8<br> <li> Installed git and kube-linter in the build stage<br> <li> Copied kube-linter binary from the build stage to the final image<br> <li> Set executable permissions for kube-linter<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/209/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

