### PR TITLE
feat: suppress helm warnings

### DIFF
--- a/scripts/helm-init
+++ b/scripts/helm-init
@@ -24,4 +24,9 @@ setup-gitlab-agent
 
 # Proceed with the other steps.
 create-ns-and-developer-role-bindings
+
+# Change permission of KUBECONFIG to avoid warnings.
+chmod 600 $KUBECONFIG || true
+
+# Init helm.
 helm-init

--- a/scripts/helm-init
+++ b/scripts/helm-init
@@ -26,7 +26,11 @@ setup-gitlab-agent
 create-ns-and-developer-role-bindings
 
 # Change permission of KUBECONFIG to avoid warnings.
-chmod 600 $KUBECONFIG || true
+if [ -n "$KUBECONFIG" ] && [ -f "$KUBECONFIG" ]; then
+  chmod 600 "$KUBECONFIG" || echo "Warning: Failed to change permissions of KUBECONFIG file" >&2
+else
+  echo "Warning: KUBECONFIG is not set or file does not exist" >&2
+fi
 
 # Init helm.
 helm-init


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Modified the `scripts/helm-init` file to address helm warnings
- Added a `chmod 600 $KUBECONFIG || true` command before initializing helm
- This change sets the correct permissions on the KUBECONFIG file, which should suppress related warnings
- The `|| true` ensures the script continues even if the chmod command fails


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helm-init</strong><dd><code>Adjust KUBECONFIG permissions to suppress warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/helm-init

<li>Added chmod command to change permissions of KUBECONFIG file to 600<br> <li> This change is made to suppress helm warnings<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/221/files#diff-3929ea18cf8363d986eb8c8490b9a9840617d7df00f7cd452a68a1d0c8bd276e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

