### PR TITLE
feat: gcp artifact registry proxy

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -15,7 +15,7 @@ services:
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
       ]
-  - name: gcp-artifact-registry-docker-proxy
+  - name: ghcr.io/persona-id/gcp-artifact-registry-docker-proxy:v1.4.0
     command:
       [
         "--registry=https://europe-west1-docker.pkg.dev/spark-int-cloud-services/docker-hub-mirror",

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -11,6 +11,7 @@ services:
         "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
         "--insecure-registry",
         "127.0.0.1:5000",
+        "--debug=true",
         "--mtu=1460",
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -14,7 +14,7 @@ services:
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
       ]
-  - name: ghcr.io/persona-id/gcp-artifact-registry-docker-proxy:v1.4.0
+  - name: ghcr.io/sparkfabrik/gcp-artifact-registry-docker-proxy:latest
     command:
       [
         "--registry=https://europe-west1-docker.pkg.dev/spark-int-cloud-services/docker-hub-mirror",

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -6,8 +6,6 @@ services:
     command:
       [
         "--registry-mirror",
-        "https://mirror.gcr.io",
-        "--registry-mirror",
         "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
         "--insecure-registry",
         "127.0.0.1:5000",

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -7,9 +7,19 @@ services:
       [
         "--registry-mirror",
         "https://mirror.gcr.io",
+        "--registry-mirror",
+        "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
+        "--insecure-registry",
+        "127.0.0.1:5000"
         "--mtu=1460",
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
+      ]
+  - name: gcp-artifact-registry-docker-proxy
+    command:
+      [
+        "--registry=https://europe-west1-docker.pkg.dev/spark-int-cloud-services/docker-hub-mirror",
+        "--listen=0.0.0.0:5000"
       ]
 variables:
   # When using dind service, we need to instruct docker to talk with

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -6,6 +6,8 @@ services:
     command:
       [
         "--registry-mirror",
+        "https://mirror.gcr.io",
+        "--registry-mirror",
         "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
         "--insecure-registry",
         "127.0.0.1:5000",

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -10,7 +10,7 @@ services:
         "--registry-mirror",
         "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
         "--insecure-registry",
-        "127.0.0.1:5000"
+        "127.0.0.1:5000",
         "--mtu=1460",
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",


### PR DESCRIPTION
### **User description**
internal #3202


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented GCP Artifact Registry proxy for Docker:
  - Added a new registry mirror pointing to a local proxy (127.0.0.1:5000)
  - Configured Docker to accept insecure connections to the local proxy
- Introduced a new service `gcp-artifact-registry-docker-proxy`:
  - Set up to proxy requests to GCP Artifact Registry (europe-west1-docker.pkg.dev)
  - Listens on 0.0.0.0:5000 to serve Docker registry requests
- These changes aim to improve Docker image pulling performance and provide a centralized cache for container images


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Configure GCP Artifact Registry proxy for Docker</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Added registry mirror for GCP Artifact Registry proxy<br> <li> Included insecure registry configuration for local proxy<br> <li> Added new service for GCP Artifact Registry Docker proxy<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/226/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

