### PR TITLE
change mirror order

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -6,9 +6,9 @@ services:
     command:
       [
         "--registry-mirror",
-        "https://mirror.gcr.io",
-        "--registry-mirror",
         "http://127.0.0.1:5000/spark-int-cloud-services/docker-hub-mirror/",
+        "--registry-mirror",
+        "https://mirror.gcr.io",
         "--insecure-registry",
         "127.0.0.1:5000",
         "--debug=true",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Reordered Docker registry mirrors to prioritize local mirror over Google Container Registry (GCR) mirror
- Changed the order of `--registry-mirror` options in the Docker service configuration
- This change aims to improve Docker image pull performance by prioritizing the local mirror
- No other changes were made to the configuration or functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Optimize Docker registry mirror order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Reordered registry mirrors in Docker service configuration<br> <li> Moved local mirror (127.0.0.1:5000) to higher priority<br> <li> Moved Google Container Registry mirror (mirror.gcr.io) to lower <br>priority<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/228/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

