### PR TITLE
feat: change compare order in if to make condition more clear

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -142,7 +142,7 @@ variables:
         
         # Default to 1 hour if not set
         DEBUG_JOB_SLEEP_SECONDS="${DEBUG_JOB_SLEEP_SECONDS:-3600}"
-        if [ "${DEBUG_JOB_SLEEP}" = "1" ] && [ "${CI_JOB_NAME_SLUG}" = "${DEBUG_JOB_SLEEP_JOB_NAME}" ]; then
+        if [ "${DEBUG_JOB_SLEEP}" = "1" ] && [ "${DEBUG_JOB_SLEEP_JOB_NAME}" = "${CI_JOB_NAME_SLUG}" ]; then
           echo "Sleeping for ${DEBUG_JOB_SLEEP_SECONDS} seconds..."
           sleep "${DEBUG_JOB_SLEEP_SECONDS}"
         fi


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved readability of the GitLab CI template by adding a missing comma in the service configuration.
- Enhanced the clarity of the debug sleep condition by changing the order of comparison in the if statement.
- The changes make the code more consistent and easier to understand without altering the functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Enhance GitLab CI template readability and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Added a comma at the end of the "--listen=0.0.0.0:5000" line in the <br>service configuration.<br> <li> Changed the order of comparison in the if statement for debug sleep <br>functionality.<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/229/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

