### PR TITLE
refs platform/#3233: restore docker context create

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -103,7 +103,7 @@ variables:
 
         if [ "${DOCKER_USE_BUILDX:-1}" = "1" ]; then
           echo "Configure buildx..."
-          # docker context create build-multiarch
+          docker context create build-multiarch
           docker buildx create build-multiarch --name buildx-builder --bootstrap --use
           docker buildx ls
         fi
@@ -128,6 +128,7 @@ variables:
         section_end "gcloud"
       fi
 
+      # Test Docker mirrors
       section_start "test-docker-mirrors" "Test Docker mirrors"
       echo "Test docker-mirror GitLab service"
       if ! nc -w10 -zv docker-mirror 5000; then


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Restored the `docker context create build-multiarch` command, which was previously commented out. This is likely to fix issues related to Docker buildx configuration.
- Added a descriptive comment "Test Docker mirrors" to improve code readability and understanding of the subsequent section.
- These changes appear to address the issue mentioned in the commit message (platform/#3233) regarding restoring Docker context creation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Restore Docker context creation and improve readability</code>&nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Uncommented the <code>docker context create build-multiarch</code> command<br> <li> Added a comment "Test Docker mirrors" before the docker mirror test <br>section<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/242/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

