### PR TITLE
refs platform/#3231: enforce the set of the default namespace for the current context if the KUBE_NAMESPACE variable is not defined

### DIFF
--- a/scripts/src/functions.bash
+++ b/scripts/src/functions.bash
@@ -199,10 +199,8 @@ _setup-gitlab-agent-kubernetes-context() {
 
   kubectl config use-context "${1}:${2}"
 
-  if [ -n "${KUBE_NAMESPACE}" ]; then
-    echo "Setting the namespace to: ${KUBE_NAMESPACE}"
-    kubectl config set-context --current --namespace="${KUBE_NAMESPACE}"
-  fi
+  echo "Setting the namespace to: ${KUBE_NAMESPACE:-default}"
+  kubectl config set-context --current --namespace="${KUBE_NAMESPACE:-default}"
 }
 
 setup-gitlab-agent() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced Kubernetes context setup to always set a namespace, using 'default' as fallback when KUBE_NAMESPACE is not defined
- Simplified code by removing conditional check and using parameter expansion with default value
- Improved robustness of GitLab agent setup by ensuring namespace is always configured



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>functions.bash</strong><dd><code>Enforce default namespace in Kubernetes context setup</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/src/functions.bash

<li>Modified <code>_setup-gitlab-agent-kubernetes-context</code> function to always set <br>namespace<br> <li> Removed conditional check for KUBE_NAMESPACE variable<br> <li> Added default fallback value 'default' when KUBE_NAMESPACE is not <br>defined<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/247/files#diff-96524718f63a467ac7a74e21082c918aa6e57208e1d794964a8c88fbb65f193c">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information