### PR TITLE
refs platform/#2862: add variable to change the image configuration for the default image and for the docker mirror image

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -1,8 +1,8 @@
-image: ghcr.io/sparkfabrik/spark-k8s-deployer:latest
+image: ${DEFAULT_IMAGE_REGISTRY}/${DEFAULT_IMAGE_REPOSITORY}:${DEFAULT_IMAGE_TAG}
 
 # MTU configuration: https://docs.gitlab.com/runner/executors/kubernetes/troubleshooting.html#curl-35-openssl-ssl_connect-ssl_error_syscall-in-connection-to-githubcom443
 services:
-  - name: ghcr.io/sparkfabrik/gcp-artifact-registry-docker-proxy:latest
+  - name: ${DOCKER_MIRROR_IMAGE_REGISTRY}/${DOCKER_MIRROR_IMAGE_REPOSITORY}:${DOCKER_MIRROR_IMAGE_TAG}
     alias: docker-mirror
     command:
       [
@@ -23,6 +23,18 @@ services:
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
       ]
 variables:
+  # Default image configuration.
+  # You can override these variables in your project's .gitlab-ci.yml file
+  # to change the image used for the jobs.
+  DEFAULT_IMAGE_REGISTRY: ghcr.io
+  DEFAULT_IMAGE_REPOSITORY: sparkfabrik/spark-k8s-deployer
+  DEFAULT_IMAGE_TAG: latest
+  # Docker-mirror image configuration.
+  # You can override these variables in your project's .gitlab-ci.yml file
+  # to change the image used for docker-mirror service.
+  DOCKER_MIRROR_IMAGE_REGISTRY: ghcr.io
+  DOCKER_MIRROR_IMAGE_REPOSITORY: sparkfabrik/gcp-artifact-registry-docker-proxy
+  DOCKER_MIRROR_IMAGE_TAG: latest
   # When using dind service, we need to instruct docker to talk with
   # the daemon started inside of the service. The daemon is available
   # with a network connection instead of the default


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Introduced configurable variables for both default and docker-mirror images in GitLab CI template
- Added ability to override image configuration through project-specific `.gitlab-ci.yml` files
- Replaced hardcoded image references with variable interpolation:
  - Default image: `${DEFAULT_IMAGE_REGISTRY}/${DEFAULT_IMAGE_REPOSITORY}:${DEFAULT_IMAGE_TAG}`
  - Docker mirror: `${DOCKER_MIRROR_IMAGE_REGISTRY}/${DOCKER_MIRROR_IMAGE_REPOSITORY}:${DOCKER_MIRROR_IMAGE_TAG}`
- Default values maintain current behavior using `ghcr.io` registry



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Configurable Docker image variables for CI template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Replaced hardcoded image references with configurable variables<br> <li> Added variables for default image configuration (registry, repository, <br>tag)<br> <li> Added variables for docker-mirror image configuration (registry, <br>repository, tag)<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/255/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information