### PR TITLE
platform/#2862: change docker-mirror to docker-proxy and variables accordingly

### DIFF
--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -2,8 +2,8 @@ image: ${DEFAULT_IMAGE_REGISTRY}/${DEFAULT_IMAGE_REPOSITORY}:${DEFAULT_IMAGE_TAG
 
 # MTU configuration: https://docs.gitlab.com/runner/executors/kubernetes/troubleshooting.html#curl-35-openssl-ssl_connect-ssl_error_syscall-in-connection-to-githubcom443
 services:
-  - name: ${DOCKER_MIRROR_IMAGE_REGISTRY}/${DOCKER_MIRROR_IMAGE_REPOSITORY}:${DOCKER_MIRROR_IMAGE_TAG}
-    alias: docker-mirror
+  - name: ${DOCKER_PROXY_IMAGE_REGISTRY}/${DOCKER_PROXY_IMAGE_REPOSITORY}:${DOCKER_PROXY_IMAGE_TAG}
+    alias: docker-proxy
     command:
       [
         "--registry=https://europe-west1-docker.pkg.dev/spark-int-cloud-services/docker-hub-mirror",
@@ -13,11 +13,11 @@ services:
     command:
       [
         "--registry-mirror",
-        "http://docker-mirror:5000/spark-int-cloud-services/docker-hub-mirror/",
+        "http://docker-proxy:5000/spark-int-cloud-services/docker-hub-mirror/",
         "--registry-mirror",
         "https://mirror.gcr.io",
         "--insecure-registry",
-        "docker-mirror:5000",
+        "docker-proxy:5000",
         "--mtu=1460",
         "--network-control-plane-mtu=1460",
         "--default-network-opt=bridge=com.docker.network.driver.mtu=1460",
@@ -29,12 +29,12 @@ variables:
   DEFAULT_IMAGE_REGISTRY: ghcr.io
   DEFAULT_IMAGE_REPOSITORY: sparkfabrik/spark-k8s-deployer
   DEFAULT_IMAGE_TAG: latest
-  # Docker-mirror image configuration.
+  # Docker-proxy image configuration.
   # You can override these variables in your project's .gitlab-ci.yml file
-  # to change the image used for docker-mirror service.
-  DOCKER_MIRROR_IMAGE_REGISTRY: ghcr.io
-  DOCKER_MIRROR_IMAGE_REPOSITORY: sparkfabrik/gcp-artifact-registry-docker-proxy
-  DOCKER_MIRROR_IMAGE_TAG: latest
+  # to change the image used for docker-proxy service.
+  DOCKER_PROXY_IMAGE_REGISTRY: ghcr.io
+  DOCKER_PROXY_IMAGE_REPOSITORY: sparkfabrik/gcp-artifact-registry-docker-proxy
+  DOCKER_PROXY_IMAGE_TAG: latest
   # When using dind service, we need to instruct docker to talk with
   # the daemon started inside of the service. The daemon is available
   # with a network connection instead of the default
@@ -144,12 +144,12 @@ variables:
       fi
 
       # Test Docker mirrors
-      section_start "test-docker-mirrors" "Test Docker mirrors"
-      echo "Test docker-mirror GitLab service"
-      if ! nc -w10 -zv docker-mirror 5000; then
-        echo "docker-mirror service not available"
+      section_start "test-docker-proxy" "Test Docker proxy"
+      echo "Test docker-proxy GitLab service"
+      if ! nc -w10 -zv docker-proxy 5000; then
+        echo "docker-proxy service not available"
       else
-        echo "docker-mirror service available"
+        echo "docker-proxy service available"
       fi
       echo "Test GCP mirror.gcr.io"
       if ! nc -w10 -zv mirror.gcr.io 443; then
@@ -157,7 +157,7 @@ variables:
       else
         echo "mirror.gcr.io service available"
       fi
-      section_end "test-docker-mirrors"
+      section_end "test-docker-proxy"
 
       # If the job is running using `spark-k8s-deployer`, source the common
       # functions and execute initialization setup.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Renamed the Docker mirror service alias from `docker-mirror` to `docker-proxy` for better clarity
- Updated all related configuration variables from DOCKER_MIRROR to DOCKER_PROXY (registry, repository, and tag)
- Modified service configuration to use new proxy naming in commands and registry URLs
- Updated diagnostic section names and messages in testing scripts to reflect new terminology



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Rename docker-mirror service and variables to docker-proxy</code></dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<li>Renamed docker service from <code>docker-mirror</code> to <code>docker-proxy</code><br> <li> Updated all related variable names from DOCKER_MIRROR to DOCKER_PROXY<br> <li> Updated service configuration and test section names to reflect new <br>naming<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/256/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+15/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information