### PR TITLE
feat: remove namespace from templates generated with helm for ArgoCD deployments

### DIFF
--- a/templates/argocd/gitlab-ci-template-gitops-argo.yml
+++ b/templates/argocd/gitlab-ci-template-gitops-argo.yml
@@ -240,6 +240,16 @@ sync to gitops repo:
       --output-dir ${INFRASTRUCTURE_REPO_DIR}/generated-manifests
       --include-crds
       --wait
+    # Remove namespace from generated manifests. ArgoCD will manage the target namespace.
+    - find ${INFRASTRUCTURE_REPO_DIR}/generated-manifests -iname '*.yml' -exec yq -i 'del(.metadata.namespace)' {} \; && find ${INFRASTRUCTURE_REPO_DIR}/generated-manifests -iname '*.yaml' -exec yq -i 'del(.metadata.namespace)' {} \;
+    # If static-manifests/${CI_COMMIT_REF_SLUG} folder exists, use envsubst to generate them.
+    # ATTENTION: the static-manifests files could OVERWRITE the helm generated ones.
+    - |
+      if [ -d "${CI_PROJECT_DIR}/static-manifests/${CI_COMMIT_REF_SLUG}" ]; then
+        for template in "${CI_PROJECT_DIR}/static-manifests/${CI_COMMIT_REF_SLUG}"/*.y*ml.tpl; do
+          envsubst < $template > "${INFRASTRUCTURE_REPO_DIR}/generated-manifests/$(basename ${template%.tpl})";
+        done
+      fi
     # Commit updated manifests to the repo.
     - git add .
     # https://stackoverflow.com/questions/3878624/how-do-i-programmatically-determine-if-there-are-uncommitted-changes
@@ -326,4 +336,3 @@ sync to gitops repo:
 #    expire_in: 1 week
 #    paths:
 #      - ${CI_PROJECT_DIR}/logs
-


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added functionality to remove namespace metadata from generated Helm manifests to allow ArgoCD to manage the target namespace
- Uses `yq` command to delete `.metadata.namespace` from all generated YAML/YML files
- This change enables better namespace management through ArgoCD deployment configuration
- Minor cleanup by removing trailing empty line



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitlab-ci-template-gitops-argo.yml</strong><dd><code>Remove namespace from Helm templates for ArgoCD management</code></dd></summary>
<hr>

templates/argocd/gitlab-ci-template-gitops-argo.yml

<li>Added command to remove namespace from generated manifests using <code>yq</code> to <br>allow ArgoCD to manage target namespace<br> <li> Removed trailing empty line


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/261/files#diff-ecbe1d0cb8018c12dca22ee3976bb5d02001da640ecd1d5ac137b00295830596">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information