### PR TITLE
paltform/#3217: remove shell dependency in output printing.

### DIFF
--- a/templates/functions/gcp-wif.yml
+++ b/templates/functions/gcp-wif.yml
@@ -73,10 +73,12 @@
       function wif_print_vars() {
         local PAD_LEN VAR_NAME
         PAD_LEN=${PAD_LEN:-40}
-        printf "\e[1mConfigured WIF related variables in order of precedence:\e[0m\n"
-        for VAR_NAME in "GCP_WIF_PROJECT_ID" "GCP_WIF_POOL" "GCP_WIF_PROVIDER" "GCP_WIF_SERVICE_ACCOUNT_EMAIL"; do
-          printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "${VAR_NAME}:" "${!VAR_NAME}"
-        done
+        if command -v bash &> /dev/null; then
+          bash -c 'printf "\e[1mConfigured WIF related variables in order of precedence:\e[0m\n"
+          for VAR_NAME in "GCP_WIF_PROJECT_ID" "GCP_WIF_POOL" "GCP_WIF_PROVIDER" "GCP_WIF_SERVICE_ACCOUNT_EMAIL"; do
+            printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "${VAR_NAME}:" "${!VAR_NAME}"
+          done'
+        fi
       }
     
     # Main script  

--- a/templates/functions/gcp-wif.yml
+++ b/templates/functions/gcp-wif.yml
@@ -71,14 +71,13 @@
       }
       
       function wif_print_vars() {
-        local PAD_LEN VAR_NAME
+        local PAD_LEN
         PAD_LEN=${PAD_LEN:-40}
-        if command -v bash &> /dev/null; then
-          bash -c 'printf "\e[1mConfigured WIF related variables in order of precedence:\e[0m\n"
-          for VAR_NAME in "GCP_WIF_PROJECT_ID" "GCP_WIF_POOL" "GCP_WIF_PROVIDER" "GCP_WIF_SERVICE_ACCOUNT_EMAIL"; do
-            printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "${VAR_NAME}:" "${!VAR_NAME}"
-          done'
-        fi
+        printf "\e[1mConfigured WIF related variables:\e[0m\n"
+        printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "GCP_WIF_PROJECT_ID:" "${GCP_WIF_PROJECT_ID}"
+        printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "GCP_WIF_POOL:" "${GCP_WIF_POOL}"
+        printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "GCP_WIF_PROVIDER:" "${GCP_WIF_PROVIDER}"
+        printf "%-${PAD_LEN}s \e[1m%s\e[0m\n" "GCP_WIF_SERVICE_ACCOUNT_EMAIL:" "${GCP_WIF_SERVICE_ACCOUNT_EMAIL}"
       }
     
     # Main script  


### PR DESCRIPTION



___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Check for bash availability before printing WIF variables

- Prevent errors in environments without bash


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcp-wif.yml</strong><dd><code>Add bash availability check for WIF variable printing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/functions/gcp-wif.yml

<li>Added check for bash availability using <code>command -v bash &> /dev/null</code><br> <li> Wrapped variable printing code in a bash execution block<br> <li> Prevents errors when bash is not available in the environment


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/274/files#diff-f09be70ddc181e2f394678d08d765b11694d30f81dfb92aa231670438fe50953">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>