### PR TITLE
platform/#3217: disable WIF by default

### DIFF
--- a/templates/functions/gcp-wif.yml
+++ b/templates/functions/gcp-wif.yml
@@ -15,7 +15,7 @@
 .gcp-wif:
   before_script:
     # Functions
-    - | 
+    - |
       function check_gcloud() {
         if ! command -v gcloud &> /dev/null; then
           echo "The gcloud command is not available. I cannot try to authenticate with GCP using the Workload Identity Federation."

--- a/templates/functions/gcp-wif.yml
+++ b/templates/functions/gcp-wif.yml
@@ -15,7 +15,7 @@
 .gcp-wif:
   before_script:
     # Functions
-    - |
+    - | 
       function check_gcloud() {
         if ! command -v gcloud &> /dev/null; then
           echo "The gcloud command is not available. I cannot try to authenticate with GCP using the Workload Identity Federation."
@@ -220,9 +220,10 @@
               "${cmd[@]}"
           fi
       }
-    # Main script  
+    # Main script
+    # Disable GCP WIF by default because it overwrites the standard runner permissions (i.e.: push to artifact registry)
     - |
-      DISABLE_GCP_WIF="${DISABLE_GCP_WIF:-0}"
+      ENABLE_GCP_WIF="${ENABLE_GCP_WIF:-0}"
       if command -v section_start &> /dev/null; then
         section_start "wif" "Workload Identity Federation"
       fi
@@ -230,14 +231,14 @@
         print-banner "GCP WIF CONFIGURATION"
       fi
       wif_print_vars
-      if [ "${DISABLE_GCP_WIF}" = 0 ]; then
+      if [ "${ENABLE_GCP_WIF}" = 1 ]; then
         if check_gcloud && check_wif_env; then
           if create_wif; then
             echo "The Workload Identity Federation authentication was successful."
           fi
         fi
       else
-        echo "The Workload Identity Federation is skipped because DISABLE_GCP_WIF is set."
+        echo "The Workload Identity Federation is skipped because ENABLE_GCP_WIF is not set."
       fi
       if command -v print-banner &> /dev/null; then
         print-banner "END GCP WIF CONFIGURATION"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Change GCP WIF to disabled by default

- Update environment variable from DISABLE_GCP_WIF to ENABLE_GCP_WIF

- Improve user messaging for WIF configuration


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcp-wif.yml</strong><dd><code>Change WIF default to opt-in instead of opt-out</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/functions/gcp-wif.yml

<li>Changed default behavior from enabled to disabled for GCP Workload <br>Identity Federation<br> <li> Replaced <code>DISABLE_GCP_WIF</code> variable with <code>ENABLE_GCP_WIF</code> (default value <br>0)<br> <li> Updated conditional logic to check for <code>ENABLE_GCP_WIF=1</code> instead of <br><code>DISABLE_GCP_WIF=0</code><br> <li> Improved user messaging to clarify why WIF is skipped


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/278/files#diff-f09be70ddc181e2f394678d08d765b11694d30f81dfb92aa231670438fe50953">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>