### PR TITLE
fix: gcp wif functions

### DIFF
--- a/templates/functions/gcp-wif.yml
+++ b/templates/functions/gcp-wif.yml
@@ -1,7 +1,7 @@
 # This template provides a script that can be used to authenticate with GCP using the Workload Identity Federation.
 # It uses functions from the `gitlab-helper-functions.yml` template; you must at least include it in your `.gitlab-ci.yml` file.
 # Example:
-# include: 
+# include:
 #   - remote: "https://raw.githubusercontent.com/sparkfabrik/spark-k8s-deployer/master/templates/functions/gitlab-helper-functions.yml"
 #   - remote: "https://raw.githubusercontent.com/sparkfabrik/spark-k8s-deployer/master/templates/functions/gcp-wif.yml"
 # test_job:
@@ -16,7 +16,7 @@
   before_script:
     # Functions
     - |
-      check_gcloud() {
+      function check_gcloud {
         if ! command -v gcloud &> /dev/null; then
           echo "The gcloud command is not available. I cannot try to authenticate with GCP using the Workload Identity Federation."
           return 1
@@ -24,7 +24,7 @@
         return 0
       }
 
-      check_wif_env() {
+      function check_wif_env {
         if [ -z "${GITLAB_OIDC_TOKEN}" ] || [ -z "${GCP_WIF_PROJECT_ID}" ] || [ -z "${GCP_WIF_POOL}" ] || [ -z "${GCP_WIF_PROVIDER}" ] || [ -z "${GCP_WIF_SERVICE_ACCOUNT_EMAIL}" ]; then
           echo "The Workload Identity Federation is not configured."
           echo "The GITLAB_OIDC_TOKEN, GCP_WIF_PROJECT_ID, GCP_WIF_POOL, GCP_WIF_PROVIDER, and GCP_WIF_SERVICE_ACCOUNT_EMAIL variables are required."
@@ -33,7 +33,7 @@
         return 0
       }
 
-      create_wif() {
+      function create_wif {
         local GCP_WIF_EXIT_CODE=0
         export GCP_WORKLOAD_IDENTITY_PROVIDER="projects/${GCP_WIF_PROJECT_ID}/locations/global/workloadIdentityPools/${GCP_WIF_POOL}/providers/${GCP_WIF_PROVIDER}"
 
@@ -69,8 +69,8 @@
 
         return ${GCP_WIF_EXIT_CODE}
       }
-      
-      wif_print_vars() {
+
+      function create_wif {
         local PAD_LEN
         PAD_LEN=${PAD_LEN:-40}
         printf "\e[1mConfigured WIF related variables:\e[0m\n"
@@ -96,7 +96,7 @@
       #   $3 - workload_identity_provider: The Workload Identity Provider ID (optional if GCP_WIF_PROVIDER is set)
       #   $4 - service_account_email: The email of the GCP service account (optional if GCP_WIF_SERVICE_ACCOUNT_EMAIL is set)
       #
-      google_wif_get_federated_token() {
+      function google_wif_get_federated_token {
         local project_id=${1:-$GCP_WIF_PROJECT_ID}
         local workload_identity_pool=${2:-$GCP_WIF_POOL}
         local workload_identity_provider=${3:-$GCP_WIF_PROVIDER}
@@ -106,7 +106,7 @@
         local section_id="google_wif_get_federated_token-${timestamp}"
 
         # Function to check if a variable is set
-        check_var() {
+        function check_var {
           local var_name=$1
           local var_value=$2
           if [ -z "$var_value" ]; then
@@ -164,7 +164,7 @@
 
         echo "$ACCESS_TOKEN"
       }
-      
+
       # Global variables with prefix
       GCLOUD_WIF_TOKEN=""
 
@@ -189,7 +189,7 @@
       #   gcloud_wif compute instances list
       #   gcloud_wif storage buckets list
       #   gcloud_wif --project=another-project compute instances list  # Overrides the default project
-      gcloud_wif() {
+      function gcloud_wif {
           # Attempt to obtain a new GCP access token if it's not set
           if [ -z "$GCLOUD_WIF_TOKEN" ]; then
               # Attempt to get the token, but continue even if it fails


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix function declarations in GCP WIF template

- Correct duplicate function name


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gcp-wif.yml</strong><dd><code>Fix shell function declarations syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/functions/gcp-wif.yml

<li>Added proper <code>function</code> keyword to all shell function declarations<br> <li> Fixed duplicate function name (<code>create_wif</code> was used twice)<br> <li> Fixed function <code>wif_print_vars</code> that was incorrectly renamed<br> <li> Minor whitespace/formatting improvements


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/280/files#diff-f09be70ddc181e2f394678d08d765b11694d30f81dfb92aa231670438fe50953">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>