### PR TITLE
refs sparkfabrik-innovation-team/board/-/issues/4199: add set-ci-as-g…

### DIFF
--- a/templates/jobs/pkgs/e2e_tests.yml
+++ b/templates/jobs/pkgs/e2e_tests.yml
@@ -1,3 +1,13 @@
+.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab:
+  script:
+    # the project in the test is not a git repo
+    - |
+      cat > additional-fs-pkg-config.yml <<'YAML'
+      sparkfabrik/pkg_composer_plugin:
+        ENABLED_CI_HANDLERS:
+          - gitlab
+      YAML
+
 .sparkfabrik-pkg-e2e-test-prepare:
   script:
     - docker run --rm -t
@@ -45,6 +55,7 @@
     PKG_COMPOSER_PLUGIN_FAKE_GITLABCI_SOURCE_URL: ${CI_PROJECT_URL}
     PKG_COMPOSER_PLUGIN_FAKE_GITLABCI_SOURCE_REF: ${CI_COMMIT_SHA}
   script:
+    - !reference [.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab]
     - !reference [.sparkfabrik-pkg-e2e-test-prepare, script]
     - !reference [.sparkfabrik-pkg-e2e-test-require, script]
   after_script:

--- a/templates/jobs/pkgs/e2e_tests.yml
+++ b/templates/jobs/pkgs/e2e_tests.yml
@@ -55,7 +55,7 @@
     PKG_COMPOSER_PLUGIN_FAKE_GITLABCI_SOURCE_URL: ${CI_PROJECT_URL}
     PKG_COMPOSER_PLUGIN_FAKE_GITLABCI_SOURCE_REF: ${CI_COMMIT_SHA}
   script:
-    - !reference [.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab]
+    - !reference [.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab, script]
     - !reference [.sparkfabrik-pkg-e2e-test-prepare, script]
     - !reference [.sparkfabrik-pkg-e2e-test-require, script]
   after_script:


### PR DESCRIPTION
### **User description**
…lab snippet


___

### **PR Type**
Enhancement


___

### **Description**
- Add new GitLab CI handler configuration snippet for e2e tests

- New job `.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab` sets CI handler to GitLab

- Reference new snippet in `.sparkfabrik-pkg-e2e-test` script execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".sparkfabrik-pkg-e2e-test-set-ci-as-gitlab"] -- "generates" --> B["additional-fs-pkg-config.yml"]
  B -- "configures" --> C["ENABLED_CI_HANDLERS: gitlab"]
  D[".sparkfabrik-pkg-e2e-test"] -- "!reference" --> A
  D -- "!reference" --> E[".sparkfabrik-pkg-e2e-test-prepare"]
  D -- "!reference" --> F[".sparkfabrik-pkg-e2e-test-require"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Add GitLab CI handler configuration snippet for e2e tests</code></dd></summary>
<hr>

templates/jobs/pkgs/e2e_tests.yml

<ul><li>Added new <code>.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab</code> job template that <br>generates an <code>additional-fs-pkg-config.yml</code> file setting GitLab as the <br>CI handler<br> <li> Integrated the new snippet into <code>.sparkfabrik-pkg-e2e-test</code> via <br><code>!reference</code> before the prepare step</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/341/files#diff-6c65a3004a875b679b15737429fecaf27daf6216c34c480fa23c9a4ef379909d">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

