### PR TITLE
Fix/gke kubeconfig posix deploy variables

### DIFF
--- a/scripts/src/functions.bash
+++ b/scripts/src/functions.bash
@@ -56,16 +56,14 @@ create_kubeconfig() {
 }
 
 ensure_deploy_variables() {
-  if [[ -n "${KUBE_NAMESPACE}" || -n "${KUBE_URL}" || -n "${KUBE_TOKEN}" || -n "${CI_ENVIRONMENT_SLUG}" || -n "${CI_ENVIRONMENT_URL}" ]]; then
-    local LEGACY_DEPLOY_VARIABLES VAR_NAME
-    LEGACY_DEPLOY_VARIABLES=("KUBE_NAMESPACE" "KUBE_URL" "KUBE_TOKEN" "CI_ENVIRONMENT_SLUG" "CI_ENVIRONMENT_URL")
-    for VAR_NAME in "${LEGACY_DEPLOY_VARIABLES[@]}"; do
-      if [[ -z "${!VAR_NAME}" ]]; then
-        echo "Missing ${VAR_NAME}."
-        exit 1
-      fi
-    done
-  fi
+  local LEGACY_DEPLOY_VARIABLES VAR_NAME
+  LEGACY_DEPLOY_VARIABLES=("KUBE_NAMESPACE" "KUBE_URL" "KUBE_TOKEN" "CI_ENVIRONMENT_SLUG" "CI_ENVIRONMENT_URL")
+  for VAR_NAME in "${LEGACY_DEPLOY_VARIABLES[@]}"; do
+    if [[ -z "${!VAR_NAME}" ]]; then
+      echo "Missing ${VAR_NAME}."
+      exit 1
+    fi
+  done
 }
 
 ping_kube() {

--- a/templates/functions/gke-kubeconfig.yml
+++ b/templates/functions/gke-kubeconfig.yml
@@ -64,17 +64,16 @@
       }
 
       generate_gke_kubeconfig() {
-        local gcloud_cmd=(
-          gcloud container clusters get-credentials "${K8S_CLUSTER_NAME}"
-          --location "${K8S_LOCATION}"
-          --project "${GCP_PROJECT_ID}"
-        )
-
+        local dns_flag=""
         if [ "${K8S_USE_DNS_ENDPOINT:-0}" = "1" ]; then
-          gcloud_cmd+=(--dns-endpoint)
+          dns_flag="--dns-endpoint"
         fi
 
-        if ! "${gcloud_cmd[@]}"; then
+        # shellcheck disable=SC2086
+        if ! gcloud container clusters get-credentials "${K8S_CLUSTER_NAME}" \
+          --location "${K8S_LOCATION}" \
+          --project "${GCP_PROJECT_ID}" \
+          ${dns_flag}; then
           return 1
         fi
 


### PR DESCRIPTION
## Summary
This PR fixes two bugs introduced by the `gke-kubeconfig` template added in #342.
### Fix shell syntax error in non-bash images (`gke-kubeconfig`)
The `generate_gke_kubeconfig()` function used bash-specific array syntax
(`local cmd=(...)`, `cmd+=(...)`, `"${cmd[@]}"`) which caused a shell parse
error when the function block was evaluated in images running `/bin/sh`
(e.g. the `secret_detection` scanner image `registry.gitlab.com/security-products/secrets:7`).
Because the global `before_script` in `.gitlab-ci-template.yml` injects
`.gke-kubeconfig` into **every** job, any job running in a non-bash image
would fail at parse time with:
syntax error: unexpected "(" (expecting "}")
The fix replaces the array-based command construction with a plain
POSIX-compatible variable flag approach.
### Fix silent no-op in `ensure_deploy_variables`
`ensure_deploy_variables()` had a conditional guard that skipped all
validation when every required variable was unset. This meant calling the
function with no variables configured was a silent no-op, allowing
`create_kubeconfig()` to proceed with empty `KUBE_URL` and `KUBE_TOKEN`
and silently produce a broken kubeconfig.
The fix removes the outer `if` guard so the function unconditionally
validates all five required variables (`KUBE_NAMESPACE`, `KUBE_URL`,
`KUBE_TOKEN`, `CI_ENVIRONMENT_SLUG`, `CI_ENVIRONMENT_URL`) whenever it
is called.
## Testing
- The `secret_detection` job (and any other job running in a non-bash
  image) no longer fails with a shell syntax error due to the inherited
  `before_script`.
- Calling `ensure_deploy_variables` with missing variables now always
  exits with an explicit error message instead of silently passing.