### PR TITLE
chore(docker): bump dind daemon and bundled client to 29.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ FROM eu.gcr.io/google.com/cloudsdktool/google-cloud-cli:${GOOGLE_CLOUD_CLI_IMAGE
 # https://github.com/docker/compose/releases
 ENV COMPOSE_VERSION=v2.38.2
 # https://download.docker.com/linux/static/stable/x86_64
-ENV DOCKER_VERSION=27.1.1
+ENV DOCKER_VERSION=29.6.1
 # https://github.com/docker/buildx/releases
 ENV DOCKER_BUILDX_VERSION=0.25.0
 # https://github.com/helm/helm/releases

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ within gitlab-ci.
 
 This image includes:
 
-- Docker client 20.10.7
+- Docker client 29.6.1
 - Docker-compose v2.23.1
 - Google cloud sdk 422.0.0
 - Helm 3.11.2 (helm3 binary)

--- a/templates/.gitlab-ci-template.yml
+++ b/templates/.gitlab-ci-template.yml
@@ -42,7 +42,7 @@ variables:
   # to change the image used for dind service.
   DOCKER_DIND_IMAGE_REGISTRY: docker.io
   DOCKER_DIND_IMAGE_REPOSITORY: library/docker
-  DOCKER_DIND_IMAGE_TAG: 26.1.0-dind-alpine3.19
+  DOCKER_DIND_IMAGE_TAG: 29.6.1-dind-alpine3.24
   # When using dind service, we need to instruct docker to talk with
   # the daemon started inside of the service. The daemon is available
   # with a network connection instead of the default


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #346

## Summary

Moves the Docker-in-Docker service image from `26.1.0-dind-alpine3.19` to `29.6.1-dind-alpine3.24` (`templates/.gitlab-ci-template.yml`) and the bundled Docker CLI client from `27.1.1` to `29.6.1` (`Dockerfile`), keeping daemon and client in lockstep. Also corrects the stale Docker client version in `README.md` (was `20.10.7`).

## Why

The dind daemon was three major Docker Engine versions behind latest stable. The jump brings security and runc CVE fixes (28.5.2) and aligns the bundled client with the daemon.

## Breaking changes mapped to this repository

| Change (version) | Affects us? | Impact |
|---|---|---|
| containerd image store now default (29) | Yes, top risk | `docker push` emits OCI manifest lists instead of schema2 (moby#51532); multi-arch `buildx --load` now works. GCP Artifact Registry accepts OCI. |
| `DOCKER_IPTABLES_LEGACY=1` versus nftables move (28/29) | Yes, verify | 29 keeps iptables-legacy unless `--firewall-backend=nftables` is set. Confirm legacy binaries still ship on `dind-alpine3.24` (docker-library/docker#443). |
| iptables and ip6tables rules restructured (28) | Yes, verify | Touches the registry-mirror to `docker-proxy:5000` path. |
| `dockerd` requires `ipset` in kernel (28) | Maybe | Needs `ipset` on the GitLab Kubernetes runner nodes. |
| LimitNOFILE 1048576 to 1024 (29) | Maybe | File-descriptor-heavy builds could hit the lower default. |

## Verification (not yet run)

The local harness `test/docker-compose.yml` is parametrized by `DOCKER_VERSION`:

1. `DOCKER_VERSION=29.6.1 docker compose -f test/docker-compose.yml up`: daemon starts, `docker info` OK, `DOCKER_IPTABLES_LEGACY=1` honored on alpine3.24.
2. Pull through `docker-proxy:5000` (registry-mirror, insecure-registry, restructured iptables).
3. `docker buildx build` multi-arch and push to a real GCP Artifact Registry; confirm the OCI manifest is pullable.
4. Watch for "too many open files" (LimitNOFILE drop).
5. Rebuild the deployer image and run a real pipeline job end-to-end before merging.

See #346 for the full changelog analysis.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump Docker-in-Docker service image from `26.1.0-dind-alpine3.19` to `29.6.1-dind-alpine3.24`

- Upgrade bundled Docker CLI client from `27.1.1` to `29.6.1`

- Fix stale Docker client version in `README.md` (was `20.10.7`)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker CLI\n27.1.1"] -- "upgrade" --> B["Docker CLI\n29.6.1"]
  C["dind image\n26.1.0-dind-alpine3.19"] -- "upgrade" --> D["dind image\n29.6.1-dind-alpine3.24"]
  B -- "kept in lockstep" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Upgrade bundled Docker CLI client to 29.6.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Bumps <code>DOCKER_VERSION</code> environment variable from <code>27.1.1</code> to <code>29.6.1</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/347/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci-template.yml</strong><dd><code>Upgrade Docker-in-Docker service image to 29.6.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/.gitlab-ci-template.yml

<ul><li>Updates <code>DOCKER_DIND_IMAGE_TAG</code> from <code>26.1.0-dind-alpine3.19</code> to <br><code>29.6.1-dind-alpine3.24</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/347/files#diff-19edaec08b5e18d84b26c97e5b8c74eb7795f285f7ed5996762475467229ba60">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix outdated Docker client version in docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Corrects stale Docker client version from `20.10.7` to `29.6.1`


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/347/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

