### PR TITLE
fix(cloudsql-db-dump): run export asynchronously and track operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- [2026.07.30] - `.cloudsql-database-dump` now runs `gcloud sql export sql` asynchronously and tracks the Cloud SQL operation until it reaches `DONE`, instead of waiting synchronously. The synchronous call gave up after about ten minutes and failed the job even when the export completed on the Google Cloud side, which was easy to hit because the dump is always gzip compressed. Two optional variables size the tracking loop, `OPERATION_WAIT_TIMEOUT` (default 300 seconds per wait) and `OPERATION_WAIT_MAX_RETRIES` (default 12), and the job now carries a `timeout: 2h` so GitLab does not stop it before the wait budget runs out.
 - [2026.06.18] - `.gke-kubeconfig` now skips gracefully (without failing the job) when `gcloud` is not available in the job image or is not authenticated, instead of exiting non-zero. This prevents build and test jobs that inherit the global `before_script` but do not need cluster access from failing when `K8S_CLUSTER_NAME` is set as a global CI/CD variable. Generation is gated on `K8S_CLUSTER_NAME` alone and is no longer coupled to `ENABLE_GCP_WIF`, so any gcloud authentication method (WIF, runner service account, service account key) is supported. It still fails fast when `gcloud` is authenticated but a required variable is missing or `get-credentials` fails.
 
 ### Changed

--- a/templates/jobs/cloudsql-db-dump.yml
+++ b/templates/jobs/cloudsql-db-dump.yml
@@ -24,9 +24,26 @@
 #       "
 #
 #   - DESTINATION_FILE_NAME_SUFFIX_OVERRIDE
-#     value: you can override the suffix that will be append to the database name to use to name the 
+#     value: you can override the suffix that will be append to the database name to use to name the
 #     databse dump. Default suffix is ${CLOUD_SQL_INSTANCE_NAME}_$(TZ=Europe/Rome date +%Y-%m-%d_%H-%M-%S).sql.gz.
 #
+# The export runs asynchronously and the job then tracks the Cloud SQL operation until it
+# completes. This is required because a synchronous `gcloud sql export sql` gives up after
+# about ten minutes and reports a failure even when the export completes correctly on the
+# Google Cloud side, which is easy to hit on large databases (the dump is always gzip
+# compressed here). Two optional variables size the tracking loop:
+#
+#   - OPERATION_WAIT_TIMEOUT
+#     value: seconds passed to a single `gcloud sql operations wait` call. Default 300.
+#
+#   - OPERATION_WAIT_MAX_RETRIES
+#     value: maximum number of wait calls before the job gives up. Default 12, which with
+#     the default timeout gives a 60 minute ceiling.
+#
+# The job carries a `timeout: 2h` so GitLab does not stop it before the wait budget runs
+# out (OPERATION_WAIT_TIMEOUT x OPERATION_WAIT_MAX_RETRIES must stay below the job
+# timeout). A job level timeout takes precedence over the project setting, but the runner
+# maximum timeout still caps it.
 #
 # Then add your job using the extends keyword (rembember to add a stage):
 #
@@ -38,11 +55,16 @@
 #
 # You must be authenticated within the project with gcloud.
 .cloudsql-database-dump:
+  # The job must outlive the operation wait budget, otherwise GitLab stops the job while
+  # the export is still running on the Cloud SQL side.
+  timeout: 2h
   variables:
     CLOUD_SQL_INSTANCE_NAME: CLOUD_SQL_INSTANCE_NAME
     GCLOUD_PROJECT_NAME: GCLOUD_PROJECT_NAME
     BUCKET_NAME: DESTINATION_BUCKET_NAME
     DESTINATION_FILE_NAME_SUFFIX_OVERRIDE: ""
+    OPERATION_WAIT_TIMEOUT: "300"
+    OPERATION_WAIT_MAX_RETRIES: "12"
     DB_NAMES: "\
       database_1 \
       database_2 \
@@ -51,26 +73,81 @@
   script:
     # Add tzdata to support timezones.
     - apk add --no-cache tzdata
-    # Dump the database.
-    - >
-      if [ -n "$DB_NAMES" ]; then
-        for DB_NAME in $DB_NAMES
-        do
-          echo "Dumping $DB_NAME production database on $BUCKET_NAME bucket..."         
-          # Build target file name suffix
-          if [ -z "$DESTINATION_FILE_NAME_SUFFIX_OVERRIDE" ]; then
-            export DESTINATION_FILE_NAME_SUFFIX="${CLOUD_SQL_INSTANCE_NAME}_$(TZ=Europe/Rome date +%Y-%m-%d_%H-%M-%S).sql.gz"
-          else
-            export DESTINATION_FILE_NAME_SUFFIX="${DESTINATION_FILE_NAME_SUFFIX_OVERRIDE}"
-          fi
-          gcloud sql export sql ${CLOUD_SQL_INSTANCE_NAME} \
-          gs://${BUCKET_NAME}/${DB_NAME}_${DESTINATION_FILE_NAME_SUFFIX} \
-          --database=${DB_NAME} --project=${GCLOUD_PROJECT_NAME} --verbosity=debug;
-        done
-      else
+    # Dump the databases.
+    - |
+      if [ -z "$DB_NAMES" ]; then
         echo "Warning, database dump skipped. Empty DB_NAME variable."
         exit 1
       fi
+
+      # Validate the wait budget, falling back to the defaults on empty or non numeric values.
+      if ! echo "$OPERATION_WAIT_TIMEOUT" | grep -Eq '^[1-9][0-9]*$'; then
+        echo "[WARNING] Ignoring invalid OPERATION_WAIT_TIMEOUT '${OPERATION_WAIT_TIMEOUT}', falling back to 300 seconds."
+        OPERATION_WAIT_TIMEOUT="300"
+      fi
+      if ! echo "$OPERATION_WAIT_MAX_RETRIES" | grep -Eq '^[1-9][0-9]*$'; then
+        echo "[WARNING] Ignoring invalid OPERATION_WAIT_MAX_RETRIES '${OPERATION_WAIT_MAX_RETRIES}', falling back to 12 attempts."
+        OPERATION_WAIT_MAX_RETRIES="12"
+      fi
+
+      for DB_NAME in $DB_NAMES; do
+        echo "Dumping $DB_NAME production database on $BUCKET_NAME bucket..."
+
+        # Build target file name suffix.
+        if [ -z "$DESTINATION_FILE_NAME_SUFFIX_OVERRIDE" ]; then
+          DESTINATION_FILE_NAME_SUFFIX="${CLOUD_SQL_INSTANCE_NAME}_$(TZ=Europe/Rome date +%Y-%m-%d_%H-%M-%S).sql.gz"
+        else
+          DESTINATION_FILE_NAME_SUFFIX="${DESTINATION_FILE_NAME_SUFFIX_OVERRIDE}"
+        fi
+
+        echo "  Operation wait timeout: ${OPERATION_WAIT_TIMEOUT}s per attempt, max ${OPERATION_WAIT_MAX_RETRIES} attempts"
+
+        # The export is started asynchronously: in synchronous mode gcloud stops polling
+        # after about ten minutes and exits non zero, even though the export completes on
+        # the Cloud SQL side.
+        if ! OPERATION="$(gcloud sql export sql "${CLOUD_SQL_INSTANCE_NAME}" "gs://${BUCKET_NAME}/${DB_NAME}_${DESTINATION_FILE_NAME_SUFFIX}" --database="${DB_NAME}" --project="${GCLOUD_PROJECT_NAME}" --async --format='value(name)')"; then
+          echo "[ERROR] Failed to start the export of the ${DB_NAME} database."
+          exit 1
+        fi
+
+        if [ -z "$OPERATION" ]; then
+          echo "[ERROR] The export of the ${DB_NAME} database was started but no operation name could be determined."
+          exit 1
+        fi
+
+        echo "[INFO] Export started, tracking Cloud SQL operation ${OPERATION}..."
+
+        STATUS=""
+        ATTEMPT=1
+        while [ "$ATTEMPT" -le "$OPERATION_WAIT_MAX_RETRIES" ]; do
+          # The exit code of `operations wait` conflates a failed operation with an expired
+          # wait, so the operation status is always read back from the API before deciding.
+          gcloud sql operations wait "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --timeout="${OPERATION_WAIT_TIMEOUT}" || true
+          STATUS="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(status)')"
+          echo "[INFO] Attempt ${ATTEMPT}/${OPERATION_WAIT_MAX_RETRIES}: operation ${OPERATION} is in status '${STATUS}'."
+
+          if [ "$STATUS" = "DONE" ]; then
+            break
+          fi
+
+          ATTEMPT=$((ATTEMPT + 1))
+        done
+
+        if [ "$STATUS" != "DONE" ]; then
+          echo "[ERROR] The export of the ${DB_NAME} database did not complete within ${OPERATION_WAIT_MAX_RETRIES} attempts of ${OPERATION_WAIT_TIMEOUT}s (last status: '${STATUS}')."
+          echo "[ERROR] Inspect it with: gcloud sql operations describe ${OPERATION} --project=${GCLOUD_PROJECT_NAME}"
+          exit 1
+        fi
+
+        OPERATION_ERROR="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(error.errors[].message)')"
+        if [ -n "$OPERATION_ERROR" ]; then
+          echo "[ERROR] The export of the ${DB_NAME} database failed: ${OPERATION_ERROR}"
+          echo "[ERROR] Inspect it with: gcloud sql operations describe ${OPERATION} --project=${GCLOUD_PROJECT_NAME}"
+          exit 1
+        fi
+
+        echo "[INFO] Dump of the ${DB_NAME} database completed on gs://${BUCKET_NAME}/${DB_NAME}_${DESTINATION_FILE_NAME_SUFFIX}."
+      done
   only:
     refs:
       - master

--- a/templates/jobs/cloudsql-db-dump.yml
+++ b/templates/jobs/cloudsql-db-dump.yml
@@ -24,8 +24,8 @@
 #       "
 #
 #   - DESTINATION_FILE_NAME_SUFFIX_OVERRIDE
-#     value: you can override the suffix that will be append to the database name to use to name the
-#     databse dump. Default suffix is ${CLOUD_SQL_INSTANCE_NAME}_$(TZ=Europe/Rome date +%Y-%m-%d_%H-%M-%S).sql.gz.
+#     value: you can override the suffix that will be appended to the database name to use to name the
+#     database dump. Default suffix is ${CLOUD_SQL_INSTANCE_NAME}_$(TZ=Europe/Rome date +%Y-%m-%d_%H-%M-%S).sql.gz.
 #
 # The export runs asynchronously and the job then tracks the Cloud SQL operation until it
 # completes. This is required because a synchronous `gcloud sql export sql` gives up after
@@ -45,7 +45,7 @@
 # timeout). A job level timeout takes precedence over the project setting, but the runner
 # maximum timeout still caps it.
 #
-# Then add your job using the extends keyword (rembember to add a stage):
+# Then add your job using the extends keyword (remember to add a stage):
 #
 #   database backup:
 #     extends: .cloudsql-database-dump
@@ -76,7 +76,7 @@
     # Dump the databases.
     - |
       if [ -z "$DB_NAMES" ]; then
-        echo "Warning, database dump skipped. Empty DB_NAME variable."
+        echo "Warning, database dump skipped. Empty DB_NAMES variable."
         exit 1
       fi
 
@@ -123,23 +123,34 @@
           # The exit code of `operations wait` conflates a failed operation with an expired
           # wait, so the operation status is always read back from the API before deciding.
           gcloud sql operations wait "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --timeout="${OPERATION_WAIT_TIMEOUT}" || true
-          STATUS="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(status)')"
-          echo "[INFO] Attempt ${ATTEMPT}/${OPERATION_WAIT_MAX_RETRIES}: operation ${OPERATION} is in status '${STATUS}'."
-
-          if [ "$STATUS" = "DONE" ]; then
-            break
+          # A failed describe (auth, network) must not look like a known non DONE status, so
+          # its exit code is checked and STATUS is left empty for this attempt on failure.
+          if STATUS="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(status)')"; then
+            echo "[INFO] Attempt ${ATTEMPT}/${OPERATION_WAIT_MAX_RETRIES}: operation ${OPERATION} is in status '${STATUS}'."
+            if [ "$STATUS" = "DONE" ]; then
+              break
+            fi
+          else
+            STATUS=""
+            echo "[WARNING] Attempt ${ATTEMPT}/${OPERATION_WAIT_MAX_RETRIES}: could not read the status of operation ${OPERATION}, will retry."
           fi
 
           ATTEMPT=$((ATTEMPT + 1))
         done
 
         if [ "$STATUS" != "DONE" ]; then
-          echo "[ERROR] The export of the ${DB_NAME} database did not complete within ${OPERATION_WAIT_MAX_RETRIES} attempts of ${OPERATION_WAIT_TIMEOUT}s (last status: '${STATUS}')."
+          echo "[ERROR] The export of the ${DB_NAME} database did not reach DONE within ${OPERATION_WAIT_MAX_RETRIES} attempts of ${OPERATION_WAIT_TIMEOUT}s (last status: '${STATUS}')."
           echo "[ERROR] Inspect it with: gcloud sql operations describe ${OPERATION} --project=${GCLOUD_PROJECT_NAME}"
           exit 1
         fi
 
-        OPERATION_ERROR="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(error.errors[].message)')"
+        # A failed describe here would yield an empty error and read as success, so its exit
+        # code is checked: an unverifiable result is treated as a failure, not a green job.
+        if ! OPERATION_ERROR="$(gcloud sql operations describe "${OPERATION}" --project="${GCLOUD_PROJECT_NAME}" --format='value(error.errors[].message)')"; then
+          echo "[ERROR] The export of the ${DB_NAME} database reached DONE but its result could not be verified (gcloud sql operations describe failed)."
+          echo "[ERROR] Inspect it with: gcloud sql operations describe ${OPERATION} --project=${GCLOUD_PROJECT_NAME}"
+          exit 1
+        fi
         if [ -n "$OPERATION_ERROR" ]; then
           echo "[ERROR] The export of the ${DB_NAME} database failed: ${OPERATION_ERROR}"
           echo "[ERROR] Inspect it with: gcloud sql operations describe ${OPERATION} --project=${GCLOUD_PROJECT_NAME}"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Stevesibilia._



## Problem

The `.cloudsql-database-dump` job ran `gcloud sql export sql` in synchronous mode. In that mode gcloud stops polling after about ten minutes and exits non zero, even though the export completes correctly on the Cloud SQL side. This template always writes a `.sql.gz` object, so the dump is always gzip compressed, which roughly doubles the export duration. A red job on a dump that actually exists in the bucket was the normal outcome for large databases.

## What changes

- **Asynchronous export.** The job starts the export with `--async` and captures the Cloud SQL operation name with `--format='value(name)'`. The `--verbosity=debug` flag is dropped from that command, since debug output on stdout would pollute the captured value.
- **Bounded tracking loop.** The job waits on the operation with `gcloud sql operations wait`, retrying until the operation settles or the budget runs out.
- **Status read back from the API.** The exit code of `operations wait` conflates a failed operation with an expired wait, so the loop always re-reads the status with `gcloud sql operations describe`. The job succeeds only when the operation is `DONE` with no error reported, and prints the Cloud SQL message when there is one.
- **Configurable budget.** Two optional variables, `OPERATION_WAIT_TIMEOUT` (default `300`) and `OPERATION_WAIT_MAX_RETRIES` (default `12`), give a 60 minute ceiling. Invalid values fall back to the defaults with a warning.
- **Job timeout.** The job carries `timeout: 2h` so GitLab does not stop it before the wait budget runs out. A job level timeout takes precedence over the project setting, and the runner maximum timeout still caps it.

The existing behaviour is otherwise preserved: the loop over `DB_NAMES`, the suffix override, the empty `DB_NAMES` guard, and the `only` rules are unchanged. The script stays POSIX `sh`, matching the Alpine image the job runs in.

## Testing

The dump script was extracted and exercised against a stubbed `gcloud`, covering 11 cases: operation done on the first wait, done on a later wait, retry budget exhausted (three attempts then failure), done with a reported error, wait exiting non zero while the operation is done, export command rejected, empty operation name, invalid timeout and invalid retry values falling back to the defaults, empty `DB_NAMES`, and two databases both completing. All 11 behave as specified. The file is valid YAML and the script passes `sh -n` and `dash -n`.

The same logic was validated end to end against a real Cloud SQL instance in the ci-cd-catalog change: a compressed export where the first `operations wait` expired at its 300 second limit with the operation still `RUNNING`, and the second attempt returned `DONE`.

## Origin

This ports the fix already merged in `sparkfabrik/ci-cd-catalog` for the `spark-drupal-deployer` component (released as `0.35.0`).


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Run `gcloud sql export sql` asynchronously and capture the operation name

- Track the Cloud SQL operation in a bounded retry loop using `operations wait` and `describe`

- Add configurable `OPERATION_WAIT_TIMEOUT` and `OPERATION_WAIT_MAX_RETRIES` variables with validation

- Set job `timeout: 2h` to outlive the wait budget


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Start export with --async"] --> B["Capture operation name"]
  B --> C["Wait loop: operations wait + describe"]
  C --> D{"Status is DONE?"}
  D -- "No, retry" --> C
  D -- "Yes" --> E["Check operation error"]
  E --> F{"Error empty?"}
  F -- "Yes" --> G["Dump completed"]
  F -- "No" --> H["Fail job"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document async dump export fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add a changelog entry under "Fixed" for the asynchronous Cloud SQL <br>dump export<br> <li> Document the new <code>OPERATION_WAIT_TIMEOUT</code> and <code>OPERATION_WAIT_MAX_RETRIES</code> <br>variables and the <code>timeout: 2h</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/348/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudsql-db-dump.yml</strong><dd><code>Implement async export and operation tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/jobs/cloudsql-db-dump.yml

<ul><li>Start <code>gcloud sql export sql</code> with <code>--async</code> and capture the operation <br>name via <code>--format='value(name)'</code><br> <li> Add a bounded retry loop using <code>gcloud sql operations wait</code> and <code>gcloud </code><br><code>sql operations describe</code> to track the operation until <code>DONE</code><br> <li> Validate <code>OPERATION_WAIT_TIMEOUT</code> and <code>OPERATION_WAIT_MAX_RETRIES</code>, <br>falling back to defaults on invalid values<br> <li> Set job <code>timeout: 2h</code> and update the header documentation for the new <br>behavior and variables</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/348/files#diff-47a3e8d143b4dbbce511fcbf4dbd6653dc0c568877fb1a9f2207b2a5a2ecf880">+95/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2