### PR TITLE
fix(e2e): fail when the generated justfile does not load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- [2026.08.13] - The deployer image ships `just`, pinned to 1.58.0. A recent version is required because it rejects justfile forms that older versions silently accept.
+- [2026.08.13] - The package e2e (`.sparkfabrik-pkg-e2e-test`) now loads the generated root justfile with `just --list` after the project is generated, through the new `.sparkfabrik-pkg-e2e-test-validate-justfile` step. `test -f` and `grep -q` pass on a justfile that `just` refuses to load, so a broken recipe attribute in a package fragment (a comment between an attribute and its recipe) shipped green; this fails the pipeline instead, and covers the whole class of justfile syntax errors, in the project file or an imported package fragment.
 - [2026.05.08] - New portable GitLab CI template `templates/functions/gke-kubeconfig.yml` (`.gke-kubeconfig`) that generates a namespace-scoped GKE kubeconfig using WIF-authenticated gcloud credentials. Activated when `ENABLE_GCP_WIF=1` and `K8S_CLUSTER_NAME` is set. Supports `K8S_USE_DNS_ENDPOINT=1` for private clusters. Runs after `setup-gitlab-agent` so the gcloud context always takes precedence. Remotely includable, no Docker image dependency.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- [2026.08.13] - The deployer image ships `just`, pinned to 1.58.0. A recent version is required because it rejects justfile forms that older versions silently accept.
+- [2026.08.13] - The deployer image ships `just`, pinned to 1.58.0 and verified against the release SHA256 before install. A recent version is required because it rejects justfile forms that older versions silently accept.
 - [2026.08.13] - The package e2e (`.sparkfabrik-pkg-e2e-test`) now loads the generated root justfile with `just --list` after the project is generated, through the new `.sparkfabrik-pkg-e2e-test-validate-justfile` step. `test -f` and `grep -q` pass on a justfile that `just` refuses to load, so a broken recipe attribute in a package fragment (a comment between an attribute and its recipe) shipped green; this fails the pipeline instead, and covers the whole class of justfile syntax errors, in the project file or an imported package fragment.
 - [2026.05.08] - New portable GitLab CI template `templates/functions/gke-kubeconfig.yml` (`.gke-kubeconfig`) that generates a namespace-scoped GKE kubeconfig using WIF-authenticated gcloud credentials. Activated when `ENABLE_GCP_WIF=1` and `K8S_CLUSTER_NAME` is set. Supports `K8S_USE_DNS_ENDPOINT=1` for private clusters. Runs after `setup-gitlab-agent` so the gcloud context always takes precedence. Remotely includable, no Docker image dependency.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ ENV YQ4_VERSION=v4.49.2
 ENV FLUX2_RELEASE_VERSION=0.26.2
 # https://github.com/stern/stern/releases
 ENV STERN_RELEASE_VERSION=1.33.1
+# https://github.com/casey/just/releases
+# A recent just is required: it rejects justfile forms that older versions
+# accept, which is how a broken package justfile can ship green.
+ENV JUST_VERSION=1.58.0
 
 # Use the gke-auth-plugin to authenticate to the GKE cluster.
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
@@ -78,7 +82,14 @@ RUN apk add --no-cache py-pip python3-dev curl make mysql-client mariadb-connect
     && tar -xvf stern_${STERN_RELEASE_VERSION}_linux_amd64.tar.gz \
     && mv stern /usr/local/bin/stern \
     && chmod +x /usr/local/bin/stern \
-    && rm -rf stern_${STERN_RELEASE_VERSION}_linux_amd64.tar.gz stern_${STERN_RELEASE_VERSION}_linux_amd64
+    && rm -rf stern_${STERN_RELEASE_VERSION}_linux_amd64.tar.gz stern_${STERN_RELEASE_VERSION}_linux_amd64 \
+    # Install just (musl static binary, matching the alpine base)
+    && curl -fSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o just.tar.gz \
+    && tar -xzf just.tar.gz just \
+    && mv just /usr/local/bin/just \
+    && chmod +x /usr/local/bin/just \
+    && rm just.tar.gz \
+    && just --version
 
 RUN pip install --no-cache-dir awscli==${AWS_CLI_VERSION} --break-system-packages
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ENV STERN_RELEASE_VERSION=1.33.1
 # A recent just is required: it rejects justfile forms that older versions
 # accept, which is how a broken package justfile can ship green.
 ENV JUST_VERSION=1.58.0
+# sha256 of just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz, from the
+# release SHA256SUMS. Bump together with JUST_VERSION.
+ENV JUST_SHA256=4a5cc2f53e6f0f8c59092a6cc38291eb729d46a7dd95d3ae582008881b84931d
 
 # Use the gke-auth-plugin to authenticate to the GKE cluster.
 ENV USE_GKE_GCLOUD_AUTH_PLUGIN=true
@@ -85,6 +88,7 @@ RUN apk add --no-cache py-pip python3-dev curl make mysql-client mariadb-connect
     && rm -rf stern_${STERN_RELEASE_VERSION}_linux_amd64.tar.gz stern_${STERN_RELEASE_VERSION}_linux_amd64 \
     # Install just (musl static binary, matching the alpine base)
     && curl -fSL "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o just.tar.gz \
+    && echo "${JUST_SHA256}  just.tar.gz" | sha256sum -c - \
     && tar -xzf just.tar.gz just \
     && mv just /usr/local/bin/just \
     && chmod +x /usr/local/bin/just \

--- a/templates/jobs/pkgs/e2e_tests.yml
+++ b/templates/jobs/pkgs/e2e_tests.yml
@@ -49,6 +49,14 @@
         && chmod +x /tmp/yaml_linting.sh && /tmp/yaml_linting.sh
       fi
 
+.sparkfabrik-pkg-e2e-test-validate-justfile:
+  script:
+    # test -f and grep -q pass on a justfile that just refuses to load, so a
+    # broken recipe attribute (for example a comment between an attribute and
+    # its recipe) ships green. Load the generated root justfile with just so any
+    # syntax error, in it or in an imported package fragment, fails the pipeline.
+    - (cd /builds/newproject && just --list > /dev/null)
+
 .sparkfabrik-pkg-e2e-test:
   variables:
     CI_TO_TEST: /builds/newproject/.gitlab-ci.yml
@@ -58,6 +66,7 @@
     - !reference [.sparkfabrik-pkg-e2e-test-set-ci-as-gitlab, script]
     - !reference [.sparkfabrik-pkg-e2e-test-prepare, script]
     - !reference [.sparkfabrik-pkg-e2e-test-require, script]
+    - !reference [.sparkfabrik-pkg-e2e-test-validate-justfile, script]
   after_script:
     - mv /builds/newproject newproject # we move the files here to gather artifacts and suppress warnings.
   artifacts:

--- a/templates/jobs/pkgs/e2e_tests.yml
+++ b/templates/jobs/pkgs/e2e_tests.yml
@@ -55,6 +55,9 @@
     # broken recipe attribute (for example a comment between an attribute and
     # its recipe) ships green. Load the generated root justfile with just so any
     # syntax error, in it or in an imported package fragment, fails the pipeline.
+    # The deployer image ships just; fail with a clear message if a job overrides
+    # the image with one that does not, instead of a bare "just: not found".
+    - command -v just > /dev/null 2>&1 || { echo "just is not available in the e2e image; it is required to validate the generated justfile"; exit 1; }
     - (cd /builds/newproject && just --list > /dev/null)
 
 .sparkfabrik-pkg-e2e-test:


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @francescoben._

## Problem

The package e2e (`.sparkfabrik-pkg-e2e-test`) validates the generated justfile only with `test -f` and `grep -q`. Both pass on a file that `just` refuses to load. A recent regression in three package justfiles shipped green because of this: the description sat as a comment between the `[group('guides')]` attribute and the recipe, and `just` 1.58 and newer reject that with `error: extraneous attribute`. Because the root justfile imports the package fragments, the error breaks every recipe (`ts-cli`, `ts-qa`, `dev`), not only the help one. CI never ran `just`, so it never saw it.

## Fix

Two parts:

- **Guard.** A new `.sparkfabrik-pkg-e2e-test-validate-justfile` step runs `just --list > /dev/null` on the generated project, referenced from `.sparkfabrik-pkg-e2e-test` after the project is generated. `just --list` parses the whole root justfile, including every imported package fragment, and exits non-zero on any syntax error. It covers the entire class, not only this case.
- **Pinned `just` in the image.** The deployer image now ships `just` 1.58.0 (musl static binary, matching the alpine base). A recent version is required: this error only appears from newer `just`, so an old one would load the broken file and keep CI green while every host is broken.

## Sequencing

`DEFAULT_IMAGE_TAG` is `latest`, so the guard depends on this PR's image build publishing `just` to `ghcr.io/sparkfabrik/spark-k8s-deployer:latest`. Merge and let the image publish before expecting the guard to run in package pipelines.

The three package justfile fixes are already open: pkg_react (https://gitlab.sparkfabrik.com/firestarter-platform/packages/react/-/merge_requests/78), pkg_nest (https://gitlab.sparkfabrik.com/firestarter-platform/packages/nest/-/merge_requests/94), pkg_next (https://gitlab.sparkfabrik.com/firestarter-platform/packages/next/-/merge_requests/96). They should merge first, so the guard passes on the next package pipeline. Found while adopting same-origin routing in clinic-reminder.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Validate generated justfiles with `just --list`

- Detect syntax errors in imported fragments

- Install pinned `just` 1.58.0 in image

- Document the new e2e validation guard


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Generate["Generate package test project"]
  Validate["Run just --list"]
  Parse["Parse root and imported justfiles"]
  Fail["Fail pipeline on syntax errors"]
  Generate -- "produces" --> Validate
  Validate -- "loads" --> Parse
  Parse -- "reports errors to" --> Fail
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document justfile syntax validation safeguards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documents the pinned <code>just</code> 1.58.0 installation.<br> <li> Documents e2e validation of generated root and imported justfiles.<br> <li> Explains why file-existence and grep checks were insufficient.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/349/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Install pinned just binary in deployer image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Adds configurable <code>JUST_VERSION</code>, pinned to <code>1.58.0</code>.<br> <li> Downloads and installs the musl static <code>just</code> binary.<br> <li> Verifies the installed executable with <code>just --version</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/349/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>e2e_tests.yml</strong><dd><code>Validate generated justfiles in package e2e tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/jobs/pkgs/e2e_tests.yml

<ul><li>Adds <code>.sparkfabrik-pkg-e2e-test-validate-justfile</code> template step.<br> <li> Runs <code>just --list</code> from the generated project directory.<br> <li> Invokes validation after package generation and installation.<br> <li> Fails package e2e pipelines for root or imported syntax errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/spark-k8s-deployer/pull/349/files#diff-6c65a3004a875b679b15737429fecaf27daf6216c34c480fa23c9a4ef379909d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra